### PR TITLE
Pluralization regex fix for words containing F

### DIFF
--- a/DapperExtensions/Mapper/PluralizedAutoClassMapper.cs
+++ b/DapperExtensions/Mapper/PluralizedAutoClassMapper.cs
@@ -32,7 +32,7 @@ namespace DapperExtensions.Mapper
                                                                                          { "tooth", "teeth" },
                                                                                          { "goose", "geese" },
                                                                                          // And now the more standard rules.
-                                                                                         { "(.*)fe?", "$1ves" },         // ie, wolf, wife
+                                                                                         { "(.*)fe?$", "$1ves" },         // ie, wolf, wife
                                                                                          { "(.*)man$", "$1men" },
                                                                                          { "(.+[aeiou]y)$", "$1s" },
                                                                                          { "(.+[^aeiou])y$", "$1ies" },


### PR DESCRIPTION
Without the $ to check for the end of the word, the (.*)fe? => $1ves
pluralization turns "profile" into "provesile", "frog" into "vesrog", 
and "muffin" into "mufvesin".
