### PR TITLE
Added check for duplicate Property mapping in Class.

### DIFF
--- a/DapperExtensions/Mapper/ClassMapper.cs
+++ b/DapperExtensions/Mapper/ClassMapper.cs
@@ -137,8 +137,17 @@ namespace DapperExtensions.Mapper
         protected PropertyMap Map(PropertyInfo propertyInfo)
         {
             PropertyMap result = new PropertyMap(propertyInfo);
+            this.GuardForDuplicatePropertyMap(result);
             Properties.Add(result);
             return result;
+        }
+
+        private void GuardForDuplicatePropertyMap(PropertyMap result)
+        {
+            if (Properties.Any(p => p.Name.Equals(result.Name)))
+            {
+                throw new ArgumentException(string.Format("Duplicate mapping for property {0} detected.",result.Name));
+            }
         }
     }
 }


### PR DESCRIPTION
Ran into a issue where having a custom CustomClassMapper that incorrectly mapped the same field twice would cause error on the Predicates (SingleOrDefault call) when building up.  

Added a guard in the mapper to detect a duplicate mapping.
