### PR TITLE
Empty PredicateGroup would create SQL output of '()'.   Return EmptyExpr...

### DIFF
--- a/DapperExtensions.Test/PredicatesFixture.cs
+++ b/DapperExtensions.Test/PredicatesFixture.cs
@@ -375,6 +375,24 @@ namespace DapperExtensions.Test
         public class PredicateGroupTests : PredicatesFixtureBase
         {
             [Test]
+            public void EmptyPredicate__CreatesNoOp_And_ReturnsProperSql()
+            {
+                Mock<IPredicate> subPredicate1 = new Mock<IPredicate>();
+                var subPredicates = new List<IPredicate> { subPredicate1.Object, subPredicate1.Object };
+                var predicate = Setup(GroupOperator.And, subPredicates);
+                var parameters = new Dictionary<string, object>();
+
+                subPredicate1.Setup(s => s.GetSql(Generator.Object, parameters)).Returns("").Verifiable();
+                var sql = predicate.Object.GetSql(Generator.Object, parameters);
+
+                predicate.Verify();
+                subPredicate1.Verify(s => s.GetSql(Generator.Object, parameters), Times.AtMost(2));
+
+                Assert.AreEqual(0, parameters.Count);
+                Assert.AreEqual("(1=1)", sql); 
+            }
+
+            [Test]
             public void GetSql_And_ReturnsProperSql()
             {
                 Mock<IPredicate> subPredicate1 = new Mock<IPredicate>();

--- a/DapperExtensions/Predicates.cs
+++ b/DapperExtensions/Predicates.cs
@@ -326,7 +326,13 @@ namespace DapperExtensions
             string seperator = Operator == GroupOperator.And ? " AND " : " OR ";
             return "(" + Predicates.Aggregate(new StringBuilder(),
                                         (sb, p) => (sb.Length == 0 ? sb : sb.Append(seperator)).Append(p.GetSql(sqlGenerator, parameters)),
-                                        sb => sb.ToString()) + ")";
+                sb =>
+                {
+                    var s = sb.ToString();
+                    if (s.Length == 0) return sqlGenerator.Configuration.Dialect.EmptyExpression; 
+                    return s;
+                }
+                                        ) + ")";
         }
     }
 

--- a/DapperExtensions/Sql/SqlDialectBase.cs
+++ b/DapperExtensions/Sql/SqlDialectBase.cs
@@ -12,6 +12,7 @@ namespace DapperExtensions.Sql
         string BatchSeperator { get; }
         bool SupportsMultipleStatements { get; }
         char ParameterPrefix { get; }
+        string EmptyExpression { get; }
         string GetTableName(string schemaName, string tableName, string alias);
         string GetColumnName(string prefix, string columnName, string alias);
         string GetIdentitySql(string tableName);
@@ -47,6 +48,14 @@ namespace DapperExtensions.Sql
             get
             {
                 return '@';
+            }
+        }
+
+        public string EmptyExpression
+        {
+            get
+            {
+                return "1=1";
             }
         }
 


### PR DESCRIPTION
Empty PredicateGroup would create SQL output of '()'.   Return EmptyExpression (1=1) instead to make valid SQL.
