### PR TITLE
Support database identifier within table name

### DIFF
--- a/DapperExtensions.Test/IntegrationTests/NonCrudFixture.cs
+++ b/DapperExtensions.Test/IntegrationTests/NonCrudFixture.cs
@@ -95,6 +95,7 @@ namespace DapperExtensions.Test.IntegrationTests
 
             private class EntityWithInterfaceMapperMapper : IClassMapper<EntityWithInterfaceMapper>
             {
+                public string DatabaseName { get; private set; }
                 public string SchemaName { get; private set; }
                 public string TableName { get; private set; }
                 public IList<IPropertyMap> Properties { get; private set; }

--- a/DapperExtensions.Test/Sql/SqlCeDialectFixture.cs
+++ b/DapperExtensions.Test/Sql/SqlCeDialectFixture.cs
@@ -39,7 +39,7 @@ namespace DapperExtensions.Test.Sql
             [Test]
             public void NullTableName_ThrowsException()
             {
-                var ex = Assert.Throws<ArgumentNullException>(() => Dialect.GetTableName(null, null, null));
+                var ex = Assert.Throws<ArgumentNullException>(() => Dialect.GetTableName(null, null, null, null));
                 Assert.AreEqual("TableName", ex.ParamName);
                 StringAssert.Contains("cannot be null", ex.Message);
             }
@@ -47,7 +47,7 @@ namespace DapperExtensions.Test.Sql
             [Test]
             public void EmptyTableName_ThrowsException()
             {
-                var ex = Assert.Throws<ArgumentNullException>(() => Dialect.GetTableName(null, string.Empty, null));
+              var ex = Assert.Throws<ArgumentNullException>( () => Dialect.GetTableName( null, null, string.Empty, null ) );
                 Assert.AreEqual("TableName", ex.ParamName);
                 StringAssert.Contains("cannot be null", ex.Message);
             }
@@ -55,21 +55,21 @@ namespace DapperExtensions.Test.Sql
             [Test]
             public void TableNameOnly_ReturnsProperlyQuoted()
             {
-                string result = Dialect.GetTableName(null, "foo", null);
+              string result = Dialect.GetTableName( null, null, "foo", null );
                 Assert.AreEqual("[foo]", result);
             }
 
             [Test]
             public void SchemaAndTable_ReturnsProperlyQuoted()
             {
-                string result = Dialect.GetTableName("bar", "foo", null);
+              string result = Dialect.GetTableName( null, "bar", "foo", null );
                 Assert.AreEqual("[bar_foo]", result);
             }
 
             [Test]
             public void AllParams_ReturnsProperlyQuoted()
             {
-                string result = Dialect.GetTableName("bar", "foo", "al");
+              string result = Dialect.GetTableName( null, "bar", "foo", "al" );
                 Assert.AreEqual("[bar_foo] AS [al]", result);
             }
         }

--- a/DapperExtensions.Test/Sql/SqlDialectBaseFixture.cs
+++ b/DapperExtensions.Test/Sql/SqlDialectBaseFixture.cs
@@ -149,7 +149,7 @@ namespace DapperExtensions.Test.Sql
             public void DatabaseAndTable_ReturnsProperlyQuoted()
             {
               string result = Dialect.GetTableName( "db", null, "foo", null );
-              Assert.AreEqual( "\"bar\".\"foo\"", result );
+              Assert.AreEqual( "\"db\"..\"foo\"", result );
             }
 
             [Test]

--- a/DapperExtensions.Test/Sql/SqlDialectBaseFixture.cs
+++ b/DapperExtensions.Test/Sql/SqlDialectBaseFixture.cs
@@ -118,7 +118,7 @@ namespace DapperExtensions.Test.Sql
             [Test]
             public void NullTableName_ThrowsException()
             {
-                var ex = Assert.Throws<ArgumentNullException>(() => Dialect.GetTableName(null, null, null));
+              var ex = Assert.Throws<ArgumentNullException>( () => Dialect.GetTableName( null, null, null, null ) );
                 Assert.AreEqual("TableName", ex.ParamName);
                 StringAssert.Contains("cannot be null", ex.Message);
             }
@@ -126,7 +126,7 @@ namespace DapperExtensions.Test.Sql
             [Test]
             public void EmptyTableName_ThrowsException()
             {
-                var ex = Assert.Throws<ArgumentNullException>(() => Dialect.GetTableName(null, string.Empty, null));
+              var ex = Assert.Throws<ArgumentNullException>( () => Dialect.GetTableName( null, null, string.Empty, null ) );
                 Assert.AreEqual("TableName", ex.ParamName);
                 StringAssert.Contains("cannot be null", ex.Message);
             }
@@ -134,28 +134,35 @@ namespace DapperExtensions.Test.Sql
             [Test]
             public void TableNameOnly_ReturnsProperlyQuoted()
             {
-                string result = Dialect.GetTableName(null, "foo", null);
+              string result = Dialect.GetTableName( null, null, "foo", null );
                 Assert.AreEqual("\"foo\"", result);
             }
 
             [Test]
             public void SchemaAndTable_ReturnsProperlyQuoted()
             {
-                string result = Dialect.GetTableName("bar", "foo", null);
+              string result = Dialect.GetTableName( null, "null, bar", "foo", null );
                 Assert.AreEqual("\"bar\".\"foo\"", result);
+            }
+
+            [Test]
+            public void DatabaseAndTable_ReturnsProperlyQuoted()
+            {
+              string result = Dialect.GetTableName( "db", null, "foo", null );
+              Assert.AreEqual( "\"bar\".\"foo\"", result );
             }
 
             [Test]
             public void AllParams_ReturnsProperlyQuoted()
             {
-                string result = Dialect.GetTableName("bar", "foo", "al");
-                Assert.AreEqual("\"bar\".\"foo\" AS \"al\"", result);
+              string result = Dialect.GetTableName( "db", "bar", "foo", "al" );
+              Assert.AreEqual( "\"db\".\"bar\".\"foo\" AS \"al\"", result );
             }
 
             [Test]
             public void ContainsQuotes_DoesNotAddExtraQuotes()
             {
-                string result = Dialect.GetTableName("\"bar\"", "\"foo\"", "\"al\"");
+              string result = Dialect.GetTableName( null, "\"bar\"", "\"foo\"", "\"al\"" );
                 Assert.AreEqual("\"bar\".\"foo\" AS \"al\"", result);
             }
         }

--- a/DapperExtensions.Test/Sql/SqlGeneratorFixture.cs
+++ b/DapperExtensions.Test/Sql/SqlGeneratorFixture.cs
@@ -710,9 +710,10 @@ namespace DapperExtensions.Test.Sql
             [Test]
             public void CallsDialect()
             {
-                ClassMap.SetupGet(c => c.SchemaName).Returns("SchemaName").Verifiable();
+              ClassMap.SetupGet( c => c.DatabaseName ).Returns( "DatabaseName" ).Verifiable();
+              ClassMap.SetupGet( c => c.SchemaName ).Returns( "SchemaName" ).Verifiable();
                 ClassMap.SetupGet(c => c.TableName).Returns("TableName").Verifiable();
-                Dialect.Setup(d => d.GetTableName("SchemaName", "TableName", null)).Returns("FullTableName").Verifiable();
+                Dialect.Setup( d => d.GetTableName( "DatabaseName", "SchemaName", "TableName", null ) ).Returns( "FullTableName" ).Verifiable();
                 var result = Generator.Object.GetTableName(ClassMap.Object);
                 Assert.AreEqual("FullTableName", result);
                 Dialect.Verify();

--- a/DapperExtensions/Mapper/ClassMapper.cs
+++ b/DapperExtensions/Mapper/ClassMapper.cs
@@ -10,6 +10,7 @@ namespace DapperExtensions.Mapper
 {
     public interface IClassMapper
     {
+        string DatabaseName { get; }
         string SchemaName { get; }
         string TableName { get; }
         IList<IPropertyMap> Properties { get; }
@@ -25,6 +26,11 @@ namespace DapperExtensions.Mapper
     /// </summary>
     public class ClassMapper<T> : IClassMapper<T> where T : class
     {
+        /// <summary>
+        /// Gets or sets the database to use when referring to the corresponding table name in the database.
+        /// </summary>
+        public string DatabaseName { get; protected set; }
+
         /// <summary>
         /// Gets or sets the schema to use when referring to the corresponding table name in the database.
         /// </summary>

--- a/DapperExtensions/Mapper/ClassMapper.cs
+++ b/DapperExtensions/Mapper/ClassMapper.cs
@@ -73,6 +73,11 @@ namespace DapperExtensions.Mapper
 
         protected Dictionary<Type, KeyType> PropertyTypeKeyTypeMapping { get; private set; }
 
+        public virtual void Database( string databaseName )
+        {
+          DatabaseName = databaseName;
+        }
+
         public virtual void Schema(string schemaName)
         {
             SchemaName = schemaName;

--- a/DapperExtensions/Sql/PostgreSqlDialect.cs
+++ b/DapperExtensions/Sql/PostgreSqlDialect.cs
@@ -31,9 +31,9 @@ namespace DapperExtensions.Sql
             return base.GetColumnName(null, columnName, alias).ToLower();
         }
 
-        public override string GetTableName(string schemaName, string tableName, string alias)
+        public override string GetTableName(string databaseName, string schemaName, string tableName, string alias)
         {
-            return base.GetTableName(schemaName, tableName, alias).ToLower();
+            return base.GetTableName( databaseName, schemaName, tableName, alias ).ToLower();
         }
     }
 

--- a/DapperExtensions/Sql/SqlCeDialect.cs
+++ b/DapperExtensions/Sql/SqlCeDialect.cs
@@ -22,11 +22,17 @@ namespace DapperExtensions.Sql
             get { return false; }
         }
 
-        public override string GetTableName(string schemaName, string tableName, string alias)
+        public override string GetTableName(string databaseName, string schemaName, string tableName, string alias)
         {
             if (string.IsNullOrWhiteSpace(tableName))
             {
                 throw new ArgumentNullException("TableName");
+            }
+
+            // SqlCe doesn't support database names within the table identifier so throw an exception if this is attempted
+            if ( !string.IsNullOrWhiteSpace( databaseName ) )
+            {
+              throw new ArgumentNullException( "SqlCe does not support the database name identifier" );
             }
 
             StringBuilder result = new StringBuilder();

--- a/DapperExtensions/Sql/SqlDialectBase.cs
+++ b/DapperExtensions/Sql/SqlDialectBase.cs
@@ -13,7 +13,7 @@ namespace DapperExtensions.Sql
         bool SupportsMultipleStatements { get; }
         char ParameterPrefix { get; }
         string EmptyExpression { get; }
-        string GetTableName(string schemaName, string tableName, string alias);
+        string GetTableName(string databaseName, string schemaName, string tableName, string alias);
         string GetColumnName(string prefix, string columnName, string alias);
         string GetIdentitySql(string tableName);
         string GetPagingSql(string sql, int page, int resultsPerPage, IDictionary<string, object> parameters);
@@ -60,7 +60,7 @@ namespace DapperExtensions.Sql
             }
         }
 
-        public virtual string GetTableName(string schemaName, string tableName, string alias)
+        public virtual string GetTableName(string databaseName, string schemaName, string tableName, string alias)
         {
             if (string.IsNullOrWhiteSpace(tableName))
             {
@@ -68,7 +68,15 @@ namespace DapperExtensions.Sql
             }
 
             StringBuilder result = new StringBuilder();
-            if (!string.IsNullOrWhiteSpace(schemaName))
+            if (!string.IsNullOrWhiteSpace(databaseName) && !string.IsNullOrWhiteSpace(schemaName))
+            {
+                result.AppendFormat(QuoteString(databaseName) + "." + QuoteString(schemaName) + ".");
+            }
+            else if (!string.IsNullOrWhiteSpace(databaseName))
+            {
+                result.AppendFormat(QuoteString(databaseName) + "..");
+            }
+            else if (!string.IsNullOrWhiteSpace(schemaName))
             {
                 result.AppendFormat(QuoteString(schemaName) + ".");
             }

--- a/DapperExtensions/Sql/SqlGenerator.cs
+++ b/DapperExtensions/Sql/SqlGenerator.cs
@@ -210,7 +210,7 @@ namespace DapperExtensions.Sql
 
         public virtual string GetTableName(IClassMapper map)
         {
-            return Configuration.Dialect.GetTableName(map.SchemaName, map.TableName, null);
+            return Configuration.Dialect.GetTableName(map.DatabaseName, map.SchemaName, map.TableName, null);
         }
 
         public virtual string GetColumnName(IClassMapper map, IPropertyMap property, bool includeAlias)


### PR DESCRIPTION
As I'm sure you are aware it is possible to identify both the database and schema within the table identifier in a number of databases technologies (e.g. SQL, Oracle etc)

The merge adds DatabaseName to the IClassMapper interface to support this process.

I've updated the core code to support this, including the base ClassMapper<T> implementation and associated tests.

As this property is added to the IClassMapper interface it does break that interface so if you'd prefer we could refactor into an IClassMapperWithDatabase interface and test for that internally. It all depends on whether you think a large number of people have implemented instances of IClassMapper and whether adding a single property to support the interface is enough of a deterrent.

Personally I use this with a DataAnnotationsClassMapper which reads my annotated DTO classes and creates maps accordingly. We have a number of separate databases for tasks such as audit and profile that are kept away from the core database and it's not ideal having to call IDBConnection.ChangeDatabase() prior to calls to the DapperExtensions.

cheers,

Gary