### PR TITLE
Ignore properties with 'XmlIgnoreAttribute' in CRUD operations

### DIFF
--- a/DapperExtensions/Mapper/ClassMapper.cs
+++ b/DapperExtensions/Mapper/ClassMapper.cs
@@ -139,6 +139,12 @@ namespace DapperExtensions.Mapper
             PropertyMap result = new PropertyMap(propertyInfo);
             this.GuardForDuplicatePropertyMap(result);
             Properties.Add(result);
+
+            // Ignore properties with 'XmlIgnoreAttribute' in CRUD operations
+            if (Attribute.GetCustomAttribute(propertyInfo, typeof(System.Xml.Serialization.XmlIgnoreAttribute))!=null)
+            {
+                result.Ignore();
+            }
             return result;
         }
 


### PR DESCRIPTION
It would be interesting to have a mechanism to ignore properties in CRUD operations:

```
public class OBJECT
{
	/// <summary> Gets or sets the ID of the object. </summary>
	public int Id { get; set; }
	/// <summary> Gets or sets the code of the object. </summary>
	public string CODE { get; set; }

	/// <summary> Returns a display text that represents the current Object. </summary>
	[System.Xml.Serialization.XmlIgnore]
	public string DisplayText
	{
		get { return string.Format("ID={0} CODE={1}", Id, CODE); }
	}
}
```

This pull implements it using XmlIgnoreAttribute item
