### PR TITLE
fixed specified cast is not valid when inserting to mysql db

### DIFF
--- a/DapperExtensions/Sql/MySqlDialect.cs
+++ b/DapperExtensions/Sql/MySqlDialect.cs
@@ -18,7 +18,7 @@ namespace DapperExtensions.Sql
 
         public override string GetIdentitySql(string tableName)
         {
-            return "SELECT LAST_INSERT_ID() AS Id";
+            return "SELECT CONVERT(LAST_INSERT_ID(), SIGNED INTEGER) AS ID";
         }
 
         public override string GetPagingSql(string sql, int page, int resultsPerPage, IDictionary<string, object> parameters)


### PR DESCRIPTION
When inserting data to mysql db i got the error: Specified cast is not valid. This is now fixed.
