### PR TITLE
exclude KeyType.Assigned properties from UPDATE'd columns

### DIFF
--- a/DapperExtensions/DapperImplementor.cs
+++ b/DapperExtensions/DapperImplementor.cs
@@ -127,7 +127,7 @@ namespace DapperExtensions
             string sql = SqlGenerator.Update(classMap, predicate, parameters);
             DynamicParameters dynamicParameters = new DynamicParameters();
 
-            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity));
+            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity || p.KeyType == KeyType.Assigned));
             foreach (var property in ReflectionHelper.GetObjectValues(entity).Where(property => columns.Any(c => c.Name == property.Key)))
             {
                 dynamicParameters.Add(property.Key, property.Value);

--- a/DapperExtensions/Sql/SqlGenerator.cs
+++ b/DapperExtensions/Sql/SqlGenerator.cs
@@ -168,7 +168,7 @@ namespace DapperExtensions.Sql
                 throw new ArgumentNullException("Parameters");
             }
 
-            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity));
+            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity || p.KeyType == KeyType.Assigned));
             if (!columns.Any())
             {
                 throw new ArgumentException("No columns were mapped.");


### PR DESCRIPTION
My project typically uses SQL Server tables that have PK's that are not identity columns, so I map them as KeyType.Assigned with ClassMapper.   While doing some testing today I noticed that Update<T> was generating SQL that was updating the PK columns, as well as including them in the where clause.  

For example, SQL Profiler showed me this:

```sql
exec sp_executesql N'UPDATE [ProdPosIss45] SET [ProdPosIss45].[StoreId] = @StoreId, [ProdPosIss45].[Upc] = @Upc, [ProdPosIss45].[MAN_PRC_FG] = @MAN_PRC_FG WHERE (([ProdPosIss45].[StoreId] = @StoreId_0) AND ([ProdPosIss45].[Upc] = @Upc_1))',N'@Upc varchar(4000),@StoreId smallint,@MAN_PRC_FG tinyint,@StoreId_0 smallint,@Upc_1 varchar(4000)',@Upc='0000000004012',@StoreId=2201,@MAN_PRC_FG=1,@StoreId_0=2201,@Upc_1='0000000004012'
```

And I was not expecting to see the PK fields being updated - I expected to only see them in the WHERE clause.

My change is to *exclude* any KeyType.Assigned properties from the UPDATE'd columns while still using them in a where clause.  Then SQL Profiler showed me this:

```sql
exec sp_executesql N'UPDATE [ProdPosIss45] SET [ProdPosIss45].[MAN_PRC_FG] = @MAN_PRC_FG WHERE (([ProdPosIss45].[StoreId] = @StoreId_0) AND ([ProdPosIss45].[Upc] = @Upc_1))',N'@MAN_PRC_FG tinyint,@StoreId_0 smallint,@Upc_1 varchar(4000)',@MAN_PRC_FG=1,@StoreId_0=2201,@Upc_1='0000000004011'
```

I was able to run all units tests (except for MySql) and all tests pass. 

This is the first PR I have ever submitted, hope it makes sense.  