### PR TITLE
Fixed parameter name typo in Postgres Dialect

### DIFF
--- a/DapperExtensions/Sql/PostgreSqlDialect.cs
+++ b/DapperExtensions/Sql/PostgreSqlDialect.cs
@@ -22,7 +22,7 @@ namespace DapperExtensions.Sql
         {
             string result = string.Format("{0} LIMIT @firstResult OFFSET @pageStartRowNbr", sql);            
             parameters.Add("@firstResult", firstResult);
-            parameters.Add("@maxResults", maxResults);
+            parameters.Add("@pageStartRowNbr", maxResults);
             return result;
         }
 


### PR DESCRIPTION
This typo causes the exception: "ERROR: 42703: column "pagestartrownbr" does not exist" when calling GetPage. 
