### PR TITLE
Attributes to control POCO properties mapping

### DIFF
--- a/DapperExtensions/Attributes/DapperIgnoreAttribute.cs
+++ b/DapperExtensions/Attributes/DapperIgnoreAttribute.cs
@@ -2,8 +2,7 @@
 
 namespace DapperExtensions.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
-    public class DapperIgnoreAttribute : Attribute
+    public class DapperIgnoreAttribute : DapperPropertyAttribute
     {
     }
 }

--- a/DapperExtensions/Attributes/DapperIgnoreAttribute.cs
+++ b/DapperExtensions/Attributes/DapperIgnoreAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DapperExtensions.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class DapperIgnoreAttribute : Attribute
+    {
+    }
+}

--- a/DapperExtensions/Attributes/DapperPropertyAttribute.cs
+++ b/DapperExtensions/Attributes/DapperPropertyAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace DapperExtensions.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public abstract class DapperPropertyAttribute : Attribute
+    {
+    }
+}

--- a/DapperExtensions/Attributes/DapperPropertyKeyTypeAttribute.cs
+++ b/DapperExtensions/Attributes/DapperPropertyKeyTypeAttribute.cs
@@ -1,0 +1,19 @@
+﻿using DapperExtensions.Mapper;
+
+namespace DapperExtensions.Attributes
+{
+    public class DapperPropertyKeyTypeAttribute : DapperPropertyAttribute
+    {
+        private readonly KeyType keyType;
+
+        public DapperPropertyKeyTypeAttribute(KeyType keyType)
+        {
+            this.keyType = keyType;
+        }
+
+        public KeyType KeyType
+        {
+            get { return keyType; }
+        }
+    }
+}

--- a/DapperExtensions/Attributes/DapperReadOnlyAttribute.cs
+++ b/DapperExtensions/Attributes/DapperReadOnlyAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace DapperExtensions.Attributes
+{
+    public class DapperReadOnlyAttribute : DapperPropertyAttribute
+    {
+    }
+}

--- a/DapperExtensions/DapperExtensions.csproj
+++ b/DapperExtensions/DapperExtensions.csproj
@@ -48,6 +48,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\DapperIgnoreAttribute.cs" />
+    <Compile Include="Attributes\DapperPropertyAttribute.cs" />
+    <Compile Include="Attributes\DapperReadOnlyAttribute.cs" />
+    <Compile Include="Attributes\DapperPropertyKeyTypeAttribute.cs" />
     <Compile Include="DapperExtensionsConfiguration.cs" />
     <Compile Include="DapperImplementor.cs" />
     <Compile Include="Database.cs" />

--- a/DapperExtensions/DapperExtensions.csproj
+++ b/DapperExtensions/DapperExtensions.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\DapperIgnoreAttribute.cs" />
     <Compile Include="DapperExtensionsConfiguration.cs" />
     <Compile Include="DapperImplementor.cs" />
     <Compile Include="Database.cs" />

--- a/DapperExtensions/DapperImplementor.cs
+++ b/DapperExtensions/DapperImplementor.cs
@@ -127,7 +127,7 @@ namespace DapperExtensions
             string sql = SqlGenerator.Update(classMap, predicate, parameters);
             DynamicParameters dynamicParameters = new DynamicParameters();
 
-            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity));
+            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity || p.KeyType == KeyType.Assigned));
             foreach (var property in ReflectionHelper.GetObjectValues(entity).Where(property => columns.Any(c => c.Name == property.Key)))
             {
                 dynamicParameters.Add(property.Key, property.Value);

--- a/DapperExtensions/Mapper/ClassMapper.cs
+++ b/DapperExtensions/Mapper/ClassMapper.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using DapperExtensions.Attributes;
 
 namespace DapperExtensions.Mapper
 {
@@ -100,6 +101,7 @@ namespace DapperExtensions.Mapper
                 }
 
                 PropertyMap map = Map(propertyInfo);
+
                 if (!hasDefinedKey)
                 {
                     if (string.Equals(map.PropertyInfo.Name, "id", StringComparison.InvariantCultureIgnoreCase))
@@ -138,6 +140,7 @@ namespace DapperExtensions.Mapper
         {
             PropertyMap result = new PropertyMap(propertyInfo);
             this.GuardForDuplicatePropertyMap(result);
+            this.CheckForIgnore(result, propertyInfo);
             Properties.Add(result);
             return result;
         }
@@ -147,6 +150,15 @@ namespace DapperExtensions.Mapper
             if (Properties.Any(p => p.Name.Equals(result.Name)))
             {
                 throw new ArgumentException(string.Format("Duplicate mapping for property {0} detected.",result.Name));
+            }
+        }
+
+        private void CheckForIgnore(PropertyMap result, PropertyInfo property)
+        {
+            var ignore = property.GetCustomAttributes(typeof (DapperIgnoreAttribute), false);
+            if (ignore.Any())
+            {
+                result.Ignore();
             }
         }
     }

--- a/DapperExtensions/Mapper/PropertyMap.cs
+++ b/DapperExtensions/Mapper/PropertyMap.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 
 namespace DapperExtensions.Mapper
@@ -25,6 +23,7 @@ namespace DapperExtensions.Mapper
     {
         public PropertyMap(PropertyInfo propertyInfo)
         {
+            KeyType = KeyType.NotAKey;
             PropertyInfo = propertyInfo;
             ColumnName = PropertyInfo.Name;
         }

--- a/DapperExtensions/Sql/SqlGenerator.cs
+++ b/DapperExtensions/Sql/SqlGenerator.cs
@@ -168,7 +168,7 @@ namespace DapperExtensions.Sql
                 throw new ArgumentNullException("Parameters");
             }
 
-            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity));
+            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity || p.KeyType == KeyType.Assigned));
             if (!columns.Any())
             {
                 throw new ArgumentException("No columns were mapped.");


### PR DESCRIPTION
It looked to me that the only way to ignore POCO properties by Dapper is to implement own mapper and override the AutoMap method (lots of SO questions refer to this). I've added couple of attributes:
- DapperIgnoreAttribute - ignores the property (using existing Ignore() method)
- DapperReadOnlyAttribute - makes property read-only with ReadOnly() method
- DapperPropertyKeyType - allows to manually specify which columns are the identity and of what kind (Identity, Guid, Assigned).

Also copied changes from this pull request: https://github.com/tmsmith/Dapper-Extensions/pull/85 which I needed (thx to @steveschoon).