### PR TITLE
#48 - Fix for GUID Primary Keys - excluding key properties from the update

### DIFF
--- a/DapperExtensions/Sql/SqlGenerator.cs
+++ b/DapperExtensions/Sql/SqlGenerator.cs
@@ -168,7 +168,7 @@ namespace DapperExtensions.Sql
                 throw new ArgumentNullException("Parameters");
             }
 
-            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity));
+            var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly) && p.KeyType == KeyType.NotAKey);
             if (!columns.Any())
             {
                 throw new ArgumentException("No columns were mapped.");


### PR DESCRIPTION
#48 looks to be open and the fix appears in the comments. I have just applied the suggested fix - excluding key columns from the updated set of columns in SqlGenerator.Update. Please review.