### PR TITLE
Add InsertUpdateOnDuplicateKey (now it's for MySQL only)

### DIFF
--- a/DapperExtensions.Test/IntegrationTests/MySql/CrudFixture.cs
+++ b/DapperExtensions.Test/IntegrationTests/MySql/CrudFixture.cs
@@ -54,6 +54,37 @@ namespace DapperExtensions.Test.IntegrationTests.MySql
                 var animals = Db.GetList<Animal>().ToList();
                 Assert.AreEqual(3, animals.Count);
             }
+
+            [Test]
+            public void InsertUpdateOnDuplicateKeyMultipleEntitiesToDatabase()
+            {
+                Animal a1 = new Animal { Name = "Foo" };
+                Animal a2 = new Animal { Name = "Bar" };
+                Animal a3 = new Animal { Name = "Baz" };
+
+                Db.InsertUpdateOnDuplicateKey<Animal>(new[] { a1, a2, a3 });
+
+                var animals = Db.GetList<Animal>().ToList();
+                Assert.AreEqual(3, animals.Count);
+            }
+
+            [Test]
+            public void InsertMultipleEntitiesToDatabase_ThenUpdateOnDuplicate()
+            {
+                string newName = "Foo_changed";
+                Animal a1 = new Animal { Name = "Foo" };
+                Animal a2 = new Animal { Name = "Bar" };
+                Animal a3 = new Animal { Name = "Baz" };
+                Animal a4 = new Animal { Name = "Moq" };
+
+                Db.InsertUpdateOnDuplicateKey<Animal>(new[] { a1, a2, a3 });
+                a1.Name = newName;
+                Db.InsertUpdateOnDuplicateKey<Animal>(new[] { a1, a4 });
+
+                var animals = Db.GetList<Animal>().ToList();
+                Assert.AreEqual(4, animals.Count);
+                Assert.True(a1.Name == animals.First(a => a.Name == newName).Name);
+            }
         }
 
         [TestFixture]

--- a/DapperExtensions.Test/IntegrationTests/SqlCe/CrudFixture.cs
+++ b/DapperExtensions.Test/IntegrationTests/SqlCe/CrudFixture.cs
@@ -54,6 +54,18 @@ namespace DapperExtensions.Test.IntegrationTests.SqlCe
                 var animals = Db.GetList<Animal>().ToList();
                 Assert.AreEqual(3, animals.Count);
             }
+
+            [Test]
+            public void InsertUpdateOnDuplicateKeyMultipleEntitiesToDatabase_ShouldThrowException()
+            {
+                Animal a1 = new Animal { Name = "Foo" };
+                Animal a2 = new Animal { Name = "Bar" };
+                Animal a3 = new Animal { Name = "Baz" };
+
+                Action action = () => Db.InsertUpdateOnDuplicateKey<Animal>(new[] { a1, a2, a3 });
+
+                Assert.Throws<NotSupportedException>(new TestDelegate(action));
+            }
         }
 
         [TestFixture]

--- a/DapperExtensions.Test/IntegrationTests/SqlServer/CrudFixture.cs
+++ b/DapperExtensions.Test/IntegrationTests/SqlServer/CrudFixture.cs
@@ -54,6 +54,18 @@ namespace DapperExtensions.Test.IntegrationTests.SqlServer
                 var animals = Db.GetList<Animal>().ToList();
                 Assert.AreEqual(3, animals.Count);
             }
+
+            [Test]
+            public void InsertUpdateOnDuplicateKeyMultipleEntitiesToDatabase_ShouldThrowException()
+            {
+                Animal a1 = new Animal { Name = "Foo" };
+                Animal a2 = new Animal { Name = "Bar" };
+                Animal a3 = new Animal { Name = "Baz" };
+
+                Action action = () => Db.InsertUpdateOnDuplicateKey<Animal>(new[] { a1, a2, a3 });
+
+                Assert.Throws<NotSupportedException>(new TestDelegate(action));
+            }
         }
 
         [TestFixture]

--- a/DapperExtensions.Test/IntegrationTests/Sqlite/CrudFixture.cs
+++ b/DapperExtensions.Test/IntegrationTests/Sqlite/CrudFixture.cs
@@ -55,6 +55,18 @@ namespace DapperExtensions.Test.IntegrationTests.Sqlite
                 var animals = Db.GetList<Animal>().ToList();
                 Assert.AreEqual(3, animals.Count);
             }
+
+            [Test]
+            public void InsertUpdateOnDuplicateKeyMultipleEntitiesToDatabase_ShouldThrowException()
+            {
+                Animal a1 = new Animal { Name = "Foo" };
+                Animal a2 = new Animal { Name = "Bar" };
+                Animal a3 = new Animal { Name = "Baz" };
+
+                Action action = () => Db.InsertUpdateOnDuplicateKey<Animal>(new[] { a1, a2, a3 });
+
+                Assert.Throws<NotSupportedException>(new TestDelegate(action));
+            }
         }
 
         [TestFixture]

--- a/DapperExtensions/DapperExtensions.cs
+++ b/DapperExtensions/DapperExtensions.cs
@@ -150,6 +150,7 @@ namespace DapperExtensions
 
         /// <summary>
         /// Executes an insert-update-on-duplicate-key query for the specified entity.
+        /// It's supported only for MqSql.
         /// </summary>
         public static void InsertUpdateOnDuplicateKey<T>(this IDbConnection connection, IEnumerable<T> entities, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {

--- a/DapperExtensions/DapperExtensions.cs
+++ b/DapperExtensions/DapperExtensions.cs
@@ -149,6 +149,14 @@ namespace DapperExtensions
         }
 
         /// <summary>
+        /// Executes an insert-update-on-duplicate-key query for the specified entity.
+        /// </summary>
+        public static void InsertUpdateOnDuplicateKey<T>(this IDbConnection connection, IEnumerable<T> entities, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
+        {
+            Instance.InsertUpdateOnDuplicateKey<T>(connection, entities, transaction, commandTimeout);
+        }
+
+        /// <summary>
         /// Executes an insert query for the specified entity, returning the primary key.  
         /// If the entity has a single key, just the value is returned.  
         /// If the entity has a composite key, an IDictionary&lt;string, object&gt; is returned with the key values.

--- a/DapperExtensions/Database.cs
+++ b/DapperExtensions/Database.cs
@@ -21,6 +21,8 @@ namespace DapperExtensions
         T Get<T>(dynamic id, int? commandTimeout = null) where T : class;
         void Insert<T>(IEnumerable<T> entities, IDbTransaction transaction, int? commandTimeout = null) where T : class;
         void Insert<T>(IEnumerable<T> entities, int? commandTimeout = null) where T : class;
+        void InsertUpdateOnDuplicateKey<T>(IEnumerable<T> entities, IDbTransaction transaction, int? commandTimeout = null) where T : class;
+        void InsertUpdateOnDuplicateKey<T>(IEnumerable<T> entities, int? commandTimeout = null) where T : class;
         dynamic Insert<T>(T entity, IDbTransaction transaction, int? commandTimeout = null) where T : class;
         dynamic Insert<T>(T entity, int? commandTimeout = null) where T : class;
         bool Update<T>(T entity, IDbTransaction transaction, int? commandTimeout = null) where T : class;
@@ -158,6 +160,16 @@ namespace DapperExtensions
         public void Insert<T>(IEnumerable<T> entities, int? commandTimeout) where T : class
         {
             _dapper.Insert<T>(Connection, entities, _transaction, commandTimeout);
+        }
+
+        public void InsertUpdateOnDuplicateKey<T>(IEnumerable<T> entities, IDbTransaction transaction, int? commandTimeout) where T : class
+        {
+            _dapper.InsertUpdateOnDuplicateKey<T>(Connection, entities, transaction, commandTimeout);
+        }
+
+        public void InsertUpdateOnDuplicateKey<T>(IEnumerable<T> entities, int? commandTimeout) where T : class
+        {
+            _dapper.InsertUpdateOnDuplicateKey<T>(Connection, entities, _transaction, commandTimeout);
         }
 
         public dynamic Insert<T>(T entity, IDbTransaction transaction, int? commandTimeout) where T : class

--- a/DapperExtensions/Sql/SqlGenerator.cs
+++ b/DapperExtensions/Sql/SqlGenerator.cs
@@ -167,7 +167,7 @@ namespace DapperExtensions.Sql
 
             var columnNames = columns.Select(p => GetColumnName(classMap, p, false));
             var parameters = columns.Select(p => Configuration.Dialect.ParameterPrefix + p.Name);
-            var valuesSetters = columns.Select(p => string.Format("{0}=VALUES({0})", GetColumnName(classMap, p, false)));
+            var valuesSetters = columns.Select(p => string.Format("{0}=VALUES({1})", GetColumnName(classMap, p, false), p.Name));
 
             string sql = string.Format("INSERT INTO {0} ({1}) VALUES ({2}) ON DUPLICATE KEY UPDATE {3}",
                                        GetTableName(classMap),


### PR DESCRIPTION
In MySQL there is very useful feature [ON DUPLICATE KEY UPDATE](http://dev.mysql.com/doc/refman/5.7/en/insert-on-duplicate.html). But it's not available in Dapper.Extensions. I tried to find a way to add this functionality outside DapperExtensions but I faced with a problem when I can't to get metadata or more info from DapperExt to implement this method outside.