### PR TITLE
Fix for slow insert performance while inserting records using MYSQL

### DIFF
--- a/DapperExtensions/DapperImplementor.cs
+++ b/DapperExtensions/DapperImplementor.cs
@@ -96,8 +96,24 @@ namespace DapperExtensions
                     result = connection.Query<long>(sql, entity, transaction, false, commandTimeout, CommandType.Text);
                 }
 
-                long identityValue = result.First();
-                int identityInt = Convert.ToInt32(identityValue);
+                // We are only interested in the first identity, but we are iterating over all resulting items (if any).
+                // This makes sure that ADO.NET drivers (like MySql) won't actively terminate the query.
+                bool hasResult = false;
+                int identityInt = 0;
+                foreach (var identityValue in result)
+                {
+                    if (hasResult)
+                    {
+                        continue;
+                    }
+                    identityInt = Convert.ToInt32(identityValue);
+                    hasResult = true;
+                }
+                if (!hasResult)
+                {
+                    throw new InvalidOperationException("The source sequence is empty.");
+                }
+
                 keyValues.Add(identityColumn.Name, identityInt);
                 identityColumn.PropertyInfo.SetValue(entity, identityInt, null);
             }


### PR DESCRIPTION
The MySQL ADO.NET driver has a feature that will terminate the main query using a seperate 'kill query connection' when the enumerator is terminated.

When insering records using DapperExtensions the LINQ First() method is used. This closes the underlying enumerator and triggers a seperate kill query connection in the MySQL driver. When inserting a lot of records this results in a massive performance decrease because the driver is constantly creating and disposing kill query connections.

Changed the insert logic so the enumerable is fully enumerated (it should only contain one identity object).
