### PR TITLE
Don't access ignored properties when using GetObjectValues

### DIFF
--- a/DapperExtensions.Test/ReflectionHelperFixture.cs
+++ b/DapperExtensions.Test/ReflectionHelperFixture.cs
@@ -22,13 +22,13 @@ namespace DapperExtensions.Test
         }
 
         [Test]
-        public void GetObjectValues_Returns_Dictionary_With_Property_Value_Pairs()
+        public void GetObjectValues_Returns_Dictionary_With_Property_ValueAccessor_Pairs()
         {
             Foo f = new Foo { Bar = 3, Baz = "Yum" };
 
             var dictionary = ReflectionHelper.GetObjectValues(f);
-            Assert.AreEqual(3, dictionary["Bar"]);
-            Assert.AreEqual("Yum", dictionary["Baz"]);
+            Assert.AreEqual(3, dictionary["Bar"]());
+            Assert.AreEqual("Yum", dictionary["Baz"]());
         }
 
         [Test]

--- a/DapperExtensions/DapperImplementor.cs
+++ b/DapperExtensions/DapperImplementor.cs
@@ -384,7 +384,8 @@ namespace DapperExtensions
         {
             Type predicateType = typeof(FieldPredicate<>).MakeGenericType(classMap.EntityType);
             IList<IPredicate> predicates = new List<IPredicate>();
-            foreach (var kvp in ReflectionHelper.GetObjectValues(entity))
+            var notIgnoredColumns = classMap.Properties.Where(p => !p.Ignored);
+            foreach (var kvp in ReflectionHelper.GetObjectValues(entity).Where(property => notIgnoredColumns.Any(c => c.Name == property.Key)))
             {
                 IFieldPredicate fieldPredicate = Activator.CreateInstance(predicateType) as IFieldPredicate;
                 fieldPredicate.Not = false;

--- a/DapperExtensions/DapperImplementor.cs
+++ b/DapperExtensions/DapperImplementor.cs
@@ -182,7 +182,7 @@ namespace DapperExtensions
             var columns = classMap.Properties.Where(p => !(p.Ignored || p.IsReadOnly || p.KeyType == KeyType.Identity || p.KeyType == KeyType.Assigned));
             foreach (var property in ReflectionHelper.GetObjectValues(entity).Where(property => columns.Any(c => c.Name == property.Key)))
             {
-                dynamicParameters.Add(property.Key, property.Value);
+                dynamicParameters.Add(property.Key, property.Value());
             }
 
             foreach (var parameter in parameters)
@@ -320,7 +320,7 @@ namespace DapperExtensions
         {
             bool isSimpleType = ReflectionHelper.IsSimpleType(id.GetType());
             var keys = classMap.Properties.Where(p => p.KeyType != KeyType.NotAKey);
-            IDictionary<string, object> paramValues = null;
+            IDictionary<string, Func<object>> paramValues = null;
             IList<IPredicate> predicates = new List<IPredicate>();
             if (!isSimpleType)
             {
@@ -332,7 +332,7 @@ namespace DapperExtensions
                 object value = id;
                 if (!isSimpleType)
                 {
-                    value = paramValues[key.Name];
+                    value = paramValues[key.Name]();
                 }
 
                 Type predicateType = typeof(FieldPredicate<>).MakeGenericType(classMap.EntityType);
@@ -390,7 +390,7 @@ namespace DapperExtensions
                 fieldPredicate.Not = false;
                 fieldPredicate.Operator = Operator.Eq;
                 fieldPredicate.PropertyName = kvp.Key;
-                fieldPredicate.Value = kvp.Value;
+                fieldPredicate.Value = kvp.Value();
                 predicates.Add(fieldPredicate);
             }
 

--- a/DapperExtensions/ReflectionHelper.cs
+++ b/DapperExtensions/ReflectionHelper.cs
@@ -54,9 +54,9 @@ namespace DapperExtensions
             }
         }
 
-        public static IDictionary<string, object> GetObjectValues(object obj)
+        public static IDictionary<string, Func<object>> GetObjectValues(object obj)
         {
-            IDictionary<string, object> result = new Dictionary<string, object>();
+            IDictionary<string, Func<object>> result = new Dictionary<string, Func<object>>();
             if (obj == null)
             {
                 return result;
@@ -66,7 +66,7 @@ namespace DapperExtensions
             foreach (var propertyInfo in obj.GetType().GetProperties())
             {
                 string name = propertyInfo.Name;
-                object value = propertyInfo.GetValue(obj, null);
+                Func<object> value = () => propertyInfo.GetValue(obj, null);
                 result[name] = value;
             }
 


### PR DESCRIPTION
The basic idea is to defer accessing the entity property only after we check that it's:
* mapped
* not ignored

We had cases when ignored props getters where doing some additional work which caused issues when called on Update