### PR TITLE
Add projection (anonymous type) support for DapperExtension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ StyleCop.*
 
 # Nuget
 packages
+/.vs/DapperExtensions/v15/Server/sqlite3

--- a/DapperExtensions.Net45/DapperAsyncImplementor.cs
+++ b/DapperExtensions.Net45/DapperAsyncImplementor.cs
@@ -19,19 +19,19 @@ namespace DapperExtensions
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.Get{T}"/>.
         /// </summary>
-        Task<T> GetAsync<T>(IDbConnection connection, dynamic id, IDbTransaction transaction = null, int? commandTimeout = null) where T : class;
+        Task<T> GetAsync<T>(IDbConnection connection, dynamic id, List<string> colToSelect, IDbTransaction transaction = null, int? commandTimeout = null) where T : class;
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.GetList{T}"/>.
         /// </summary>
-        Task<IEnumerable<T>> GetListAsync<T>(IDbConnection connection, object predicate = null, IList<ISort> sort = null, IDbTransaction transaction = null, int? commandTimeout = null) where T : class;
+        Task<IEnumerable<T>> GetListAsync<T>(IDbConnection connection, List<string> colToSelect, object predicate = null, IList<ISort> sort = null, IDbTransaction transaction = null, int? commandTimeout = null) where T : class;
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.GetPage{T}"/>.
         /// </summary>
-        Task<IEnumerable<T>> GetPageAsync<T>(IDbConnection connection, object predicate = null, IList<ISort> sort = null, int page = 1, int resultsPerPage = 10, IDbTransaction transaction = null, int? commandTimeout = null) where T : class;
+        Task<IEnumerable<T>> GetPageAsync<T>(IDbConnection connection, List<string> colToSelect, object predicate = null, IList<ISort> sort = null, int page = 1, int resultsPerPage = 10, IDbTransaction transaction = null, int? commandTimeout = null) where T : class;
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.GetSet{T}"/>.
         /// </summary>
-        Task<IEnumerable<T>> GetSetAsync<T>(IDbConnection connection, object predicate = null, IList<ISort> sort = null, int firstResult = 1, int maxResults = 10, IDbTransaction transaction = null, int? commandTimeout = null) where T : class;
+        Task<IEnumerable<T>> GetSetAsync<T>(IDbConnection connection, List<string> colToSelect, object predicate = null, IList<ISort> sort = null, int firstResult = 1, int maxResults = 10, IDbTransaction transaction = null, int? commandTimeout = null) where T : class;
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.Count{T}"/>.
         /// </summary>
@@ -48,7 +48,7 @@ namespace DapperExtensions
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.Update{T}(IDbConnection, T, IDbTransaction, int?)"/>.
         /// </summary>
-        Task<bool> UpdateAsync<T>(IDbConnection connection, T entity, IDbTransaction transaction, int? commandTimeout, bool ignoreAllKeyProperties = false) where T : class;
+        Task<bool> UpdateAsync<T>(IDbConnection connection, T entity, IDbTransaction transaction, List<string> colToUpdate, int? commandTimeout, bool ignoreAllKeyProperties = false) where T : class;
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.Delete{T}(IDbConnection, T, IDbTransaction, int?)"/>.
         /// </summary>
@@ -203,12 +203,12 @@ namespace DapperExtensions
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.Update{T}(IDbConnection, T, IDbTransaction, int?)"/>.
         /// </summary>
-        public async Task<bool> UpdateAsync<T>(IDbConnection connection, T entity, IDbTransaction transaction, int? commandTimeout, bool ignoreAllKeyProperties) where T : class
+        public async Task<bool> UpdateAsync<T>(IDbConnection connection, T entity, IDbTransaction transaction, List<string> colToUpdate ,int? commandTimeout, bool ignoreAllKeyProperties) where T : class
         {
             var classMap = SqlGenerator.Configuration.GetMap<T>();
             var predicate = GetKeyPredicate<T>(classMap, entity);
             var parameters = new Dictionary<string, object>();
-            var sql = SqlGenerator.Update(classMap, predicate, parameters, ignoreAllKeyProperties);
+            var sql = SqlGenerator.Update(classMap, predicate, parameters, ignoreAllKeyProperties, colToUpdate);
             var dynamicParameters = new DynamicParameters();
 
             var columns = ignoreAllKeyProperties
@@ -259,45 +259,45 @@ namespace DapperExtensions
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.Get{T}"/>.
         /// </summary>
-        public async Task<T> GetAsync<T>(IDbConnection connection, dynamic id, IDbTransaction transaction = null,
+        public async Task<T> GetAsync<T>(IDbConnection connection, dynamic id, List<string> colToSelect, IDbTransaction transaction = null,
             int? commandTimeout = null) where T : class
         {
             IClassMapper classMap = SqlGenerator.Configuration.GetMap<T>();
             IPredicate predicate = GetIdPredicate(classMap, id);
-            return (await GetListAsync<T>(connection, classMap, predicate, null, transaction, commandTimeout)).SingleOrDefault();
+            return (await GetListAsync<T>(connection, colToSelect, classMap, predicate, null, transaction, commandTimeout)).SingleOrDefault();
         }
 
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.GetList{T}"/>.
         /// </summary>
-        public async Task<IEnumerable<T>> GetListAsync<T>(IDbConnection connection, object predicate = null, IList<ISort> sort = null,
+        public async Task<IEnumerable<T>> GetListAsync<T>(IDbConnection connection, List<string> colToSelect, object predicate = null, IList<ISort> sort = null,
             IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             IClassMapper classMap = SqlGenerator.Configuration.GetMap<T>();
             IPredicate wherePredicate = GetPredicate(classMap, predicate);
-            return await GetListAsync<T>(connection, classMap, wherePredicate, sort, transaction, commandTimeout);
+            return await GetListAsync<T>(connection, colToSelect, classMap, wherePredicate, sort, transaction, commandTimeout);
         }
 
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.GetPage{T}"/>.
         /// </summary>
-        public async Task<IEnumerable<T>> GetPageAsync<T>(IDbConnection connection, object predicate = null, IList<ISort> sort = null, int page = 1,
+        public async Task<IEnumerable<T>> GetPageAsync<T>(IDbConnection connection, List<string> colToSelect, object predicate = null, IList<ISort> sort = null, int page = 1,
             int resultsPerPage = 10, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             IClassMapper classMap = SqlGenerator.Configuration.GetMap<T>();
             IPredicate wherePredicate = GetPredicate(classMap, predicate);
-            return await GetPageAsync<T>(connection, classMap, wherePredicate, sort, page, resultsPerPage, transaction, commandTimeout);
+            return await GetPageAsync<T>(connection, colToSelect, classMap, wherePredicate, sort, page, resultsPerPage, transaction, commandTimeout);
         }
 
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.GetSet{T}"/>.
         /// </summary>
-        public async Task<IEnumerable<T>> GetSetAsync<T>(IDbConnection connection, object predicate = null, IList<ISort> sort = null, int firstResult = 1,
+        public async Task<IEnumerable<T>> GetSetAsync<T>(IDbConnection connection, List<string> colToSelect, object predicate = null, IList<ISort> sort = null, int firstResult = 1,
             int maxResults = 10, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
             IClassMapper classMap = SqlGenerator.Configuration.GetMap<T>();
             IPredicate wherePredicate = GetPredicate(classMap, predicate);
-            return await GetSetAsync<T>(connection, classMap, wherePredicate, sort, firstResult, maxResults, transaction, commandTimeout);
+            return await GetSetAsync<T>(connection,colToSelect, classMap, wherePredicate, sort, firstResult, maxResults, transaction, commandTimeout);
         }
 
         /// <summary>
@@ -326,10 +326,10 @@ namespace DapperExtensions
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.GetList{T}"/>.
         /// </summary>
-        protected async Task<IEnumerable<T>> GetListAsync<T>(IDbConnection connection, IClassMapper classMap, IPredicate predicate, IList<ISort> sort, IDbTransaction transaction, int? commandTimeout) where T : class
+        protected async Task<IEnumerable<T>> GetListAsync<T>(IDbConnection connection, List<string> colToSelect, IClassMapper classMap, IPredicate predicate, IList<ISort> sort, IDbTransaction transaction, int? commandTimeout) where T : class
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
-            string sql = SqlGenerator.Select(classMap, predicate, sort, parameters);
+            string sql = SqlGenerator.Select(classMap, predicate, sort, parameters, colToSelect);
             DynamicParameters dynamicParameters = new DynamicParameters();
             foreach (var parameter in parameters)
             {
@@ -342,10 +342,10 @@ namespace DapperExtensions
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.GetPage{T}"/>.
         /// </summary>
-        protected async Task<IEnumerable<T>> GetPageAsync<T>(IDbConnection connection, IClassMapper classMap, IPredicate predicate, IList<ISort> sort, int page, int resultsPerPage, IDbTransaction transaction, int? commandTimeout) where T : class
+        protected async Task<IEnumerable<T>> GetPageAsync<T>(IDbConnection connection, List<string> colToSelect, IClassMapper classMap, IPredicate predicate, IList<ISort> sort, int page, int resultsPerPage, IDbTransaction transaction, int? commandTimeout) where T : class
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
-            string sql = SqlGenerator.SelectPaged(classMap, predicate, sort, page, resultsPerPage, parameters);
+            string sql = SqlGenerator.SelectPaged(classMap, predicate, sort, page, resultsPerPage, parameters, colToSelect);
             DynamicParameters dynamicParameters = new DynamicParameters();
             foreach (var parameter in parameters)
             {
@@ -358,10 +358,10 @@ namespace DapperExtensions
         /// <summary>
         /// The asynchronous counterpart to <see cref="IDapperImplementor.GetSet{T}"/>.
         /// </summary>
-        protected async Task<IEnumerable<T>> GetSetAsync<T>(IDbConnection connection, IClassMapper classMap, IPredicate predicate, IList<ISort> sort, int firstResult, int maxResults, IDbTransaction transaction, int? commandTimeout) where T : class
+        protected async Task<IEnumerable<T>> GetSetAsync<T>(IDbConnection connection, List<string> colToSelect, IClassMapper classMap, IPredicate predicate, IList<ISort> sort, int firstResult, int maxResults, IDbTransaction transaction, int? commandTimeout) where T : class
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
-            string sql = SqlGenerator.SelectSet(classMap, predicate, sort, firstResult, maxResults, parameters);
+            string sql = SqlGenerator.SelectSet(classMap, predicate, sort, firstResult, maxResults, parameters, colToSelect);
             DynamicParameters dynamicParameters = new DynamicParameters();
             foreach (var parameter in parameters)
             {

--- a/DapperExtensions.Test/Sql/SqlGeneratorFixture.cs
+++ b/DapperExtensions.Test/Sql/SqlGeneratorFixture.cs
@@ -42,7 +42,7 @@ namespace DapperExtensions.Test.Sql
             {
                 Sort sort = new Sort();
                 var ex = Assert.Throws<ArgumentNullException>(
-                    () => Generator.Object.Select(ClassMap.Object, null, null, null));
+                    () => Generator.Object.Select(ClassMap.Object, null, null, null, null));
                 StringAssert.Contains("cannot be null", ex.Message);
                 Assert.AreEqual("Parameters", ex.ParamName);
             }
@@ -53,9 +53,9 @@ namespace DapperExtensions.Test.Sql
                 IDictionary<string, object> parameters = new Dictionary<string, object>();
 
                 Generator.Setup(g => g.GetTableName(ClassMap.Object)).Returns("TableName").Verifiable();
-                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object)).Returns("Columns").Verifiable();
+                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object, null)).Returns("Columns").Verifiable();
 
-                var result = Generator.Object.Select(ClassMap.Object, null, null, parameters);
+                var result = Generator.Object.Select(ClassMap.Object, null, null, parameters, null);
                 Assert.AreEqual("SELECT Columns FROM TableName", result);
                 ClassMap.Verify();
                 Generator.Verify();
@@ -69,9 +69,9 @@ namespace DapperExtensions.Test.Sql
                 predicate.Setup(p => p.GetSql(Generator.Object, parameters)).Returns("PredicateWhere");
 
                 Generator.Setup(g => g.GetTableName(ClassMap.Object)).Returns("TableName").Verifiable();
-                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object)).Returns("Columns").Verifiable();
+                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object, null)).Returns("Columns").Verifiable();
 
-                var result = Generator.Object.Select(ClassMap.Object, predicate.Object, null, parameters);
+                var result = Generator.Object.Select(ClassMap.Object, predicate.Object, null, parameters, null);
                 Assert.AreEqual("SELECT Columns FROM TableName WHERE PredicateWhere", result);
                 ClassMap.Verify();
                 predicate.Verify();
@@ -92,10 +92,10 @@ namespace DapperExtensions.Test.Sql
                                        };
 
                 Generator.Setup(g => g.GetTableName(ClassMap.Object)).Returns("TableName").Verifiable();
-                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object)).Returns("Columns").Verifiable();
+                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object, null)).Returns("Columns").Verifiable();
                 Generator.Setup(g => g.GetColumnName(ClassMap.Object, "SortProperty", false)).Returns("SortColumn").Verifiable();
 
-                var result = Generator.Object.Select(ClassMap.Object, null, sort, parameters);
+                var result = Generator.Object.Select(ClassMap.Object, null, sort, parameters, null);
                 Assert.AreEqual("SELECT Columns FROM TableName ORDER BY SortColumn ASC", result);
                 ClassMap.Verify();
                 sortField.Verify();
@@ -118,10 +118,10 @@ namespace DapperExtensions.Test.Sql
                 predicate.Setup(p => p.GetSql(Generator.Object, parameters)).Returns("PredicateWhere");
 
                 Generator.Setup(g => g.GetTableName(ClassMap.Object)).Returns("TableName").Verifiable();
-                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object)).Returns("Columns").Verifiable();
+                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object, null)).Returns("Columns").Verifiable();
                 Generator.Setup(g => g.GetColumnName(ClassMap.Object, "SortProperty", false)).Returns("SortColumn").Verifiable();
 
-                var result = Generator.Object.Select(ClassMap.Object, predicate.Object, sort, parameters);
+                var result = Generator.Object.Select(ClassMap.Object, predicate.Object, sort, parameters, null);
                 Assert.AreEqual("SELECT Columns FROM TableName WHERE PredicateWhere ORDER BY SortColumn ASC", result);
                 ClassMap.Verify();
                 sortField.Verify();
@@ -137,7 +137,7 @@ namespace DapperExtensions.Test.Sql
             public void WithNoSort_ThrowsException()
             {
                 var ex = Assert.Throws<ArgumentNullException>(
-                    () => Generator.Object.SelectPaged(ClassMap.Object, null, null, 0, 1, new Dictionary<string, object>()));
+                    () => Generator.Object.SelectPaged(ClassMap.Object, null, null, 0, 1, new Dictionary<string, object>(), null));
                 StringAssert.Contains("null or empty", ex.Message);
             }
 
@@ -145,7 +145,7 @@ namespace DapperExtensions.Test.Sql
             public void WithEmptySort_ThrowsException()
             {
                 var ex = Assert.Throws<ArgumentNullException>(
-                    () => Generator.Object.SelectPaged(ClassMap.Object, null, new List<ISort>(), 0, 1, new Dictionary<string, object>()));
+                    () => Generator.Object.SelectPaged(ClassMap.Object, null, new List<ISort>(), 0, 1, new Dictionary<string, object>(), null));
                 StringAssert.Contains("null or empty", ex.Message);
                 Assert.AreEqual("Sort", ex.ParamName);
             }
@@ -155,7 +155,7 @@ namespace DapperExtensions.Test.Sql
             {
                 Sort sort = new Sort();
                 var ex = Assert.Throws<ArgumentNullException>(
-                    () => Generator.Object.SelectPaged(ClassMap.Object, null, new List<ISort> { sort }, 0, 1, null));
+                    () => Generator.Object.SelectPaged(ClassMap.Object, null, new List<ISort> { sort }, 0, 1, null, null));
                 StringAssert.Contains("cannot be null", ex.Message);
                 Assert.AreEqual("Parameters", ex.ParamName);
             }
@@ -173,12 +173,12 @@ namespace DapperExtensions.Test.Sql
                                        };
 
                 Generator.Setup(g => g.GetTableName(ClassMap.Object)).Returns("TableName").Verifiable();
-                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object)).Returns("Columns").Verifiable();
+                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object, null)).Returns("Columns").Verifiable();
                 Generator.Setup(g => g.GetColumnName(ClassMap.Object, "SortProperty", false)).Returns("SortColumn").Verifiable();
 
                 Dialect.Setup(d => d.GetPagingSql("SELECT Columns FROM TableName ORDER BY SortColumn ASC", 2, 10, parameters)).Returns("PagedSQL").Verifiable();
 
-                var result = Generator.Object.SelectPaged(ClassMap.Object, null, sort, 2, 10, parameters);
+                var result = Generator.Object.SelectPaged(ClassMap.Object, null, sort, 2, 10, parameters, null);
                 Assert.AreEqual("PagedSQL", result);
                 ClassMap.Verify();
                 sortField.Verify();
@@ -202,12 +202,12 @@ namespace DapperExtensions.Test.Sql
                 predicate.Setup(p => p.GetSql(Generator.Object, parameters)).Returns("PredicateWhere");
 
                 Generator.Setup(g => g.GetTableName(ClassMap.Object)).Returns("TableName").Verifiable();
-                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object)).Returns("Columns").Verifiable();
+                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object, null)).Returns("Columns").Verifiable();
                 Generator.Setup(g => g.GetColumnName(ClassMap.Object, "SortProperty", false)).Returns("SortColumn").Verifiable();
 
                 Dialect.Setup(d => d.GetPagingSql("SELECT Columns FROM TableName WHERE PredicateWhere ORDER BY SortColumn ASC", 2, 10, parameters)).Returns("PagedSQL").Verifiable();
 
-                var result = Generator.Object.SelectPaged(ClassMap.Object, predicate.Object, sort, 2, 10, parameters);
+                var result = Generator.Object.SelectPaged(ClassMap.Object, predicate.Object, sort, 2, 10, parameters, null);
                 Assert.AreEqual("PagedSQL", result);
                 ClassMap.Verify();
                 sortField.Verify();
@@ -223,7 +223,7 @@ namespace DapperExtensions.Test.Sql
             public void WithNoSort_ThrowsException()
             {
                 var ex = Assert.Throws<ArgumentNullException>(
-                    () => Generator.Object.SelectSet(ClassMap.Object, null, null, 0, 1, new Dictionary<string, object>()));
+                    () => Generator.Object.SelectSet(ClassMap.Object, null, null, 0, 1, new Dictionary<string, object>(), null));
                 StringAssert.Contains("null or empty", ex.Message);
             }
 
@@ -231,7 +231,7 @@ namespace DapperExtensions.Test.Sql
             public void WithEmptySort_ThrowsException()
             {
                 var ex = Assert.Throws<ArgumentNullException>(
-                    () => Generator.Object.SelectSet(ClassMap.Object, null, new List<ISort>(), 0, 1, new Dictionary<string, object>()));
+                    () => Generator.Object.SelectSet(ClassMap.Object, null, new List<ISort>(), 0, 1, new Dictionary<string, object>(), null));
                 StringAssert.Contains("null or empty", ex.Message);
                 Assert.AreEqual("Sort", ex.ParamName);
             }
@@ -241,7 +241,7 @@ namespace DapperExtensions.Test.Sql
             {
                 Sort sort = new Sort();
                 var ex = Assert.Throws<ArgumentNullException>(
-                    () => Generator.Object.SelectSet(ClassMap.Object, null, new List<ISort> { sort }, 0, 1, null));
+                    () => Generator.Object.SelectSet(ClassMap.Object, null, new List<ISort> { sort }, 0, 1, null, null));
                 StringAssert.Contains("cannot be null", ex.Message);
                 Assert.AreEqual("Parameters", ex.ParamName);
             }
@@ -259,12 +259,12 @@ namespace DapperExtensions.Test.Sql
                                        };
 
                 Generator.Setup(g => g.GetTableName(ClassMap.Object)).Returns("TableName").Verifiable();
-                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object)).Returns("Columns").Verifiable();
+                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object, null)).Returns("Columns").Verifiable();
                 Generator.Setup(g => g.GetColumnName(ClassMap.Object, "SortProperty", false)).Returns("SortColumn").Verifiable();
 
                 Dialect.Setup(d => d.GetSetSql("SELECT Columns FROM TableName ORDER BY SortColumn ASC", 2, 10, parameters)).Returns("PagedSQL").Verifiable();
 
-                var result = Generator.Object.SelectSet(ClassMap.Object, null, sort, 2, 10, parameters);
+                var result = Generator.Object.SelectSet(ClassMap.Object, null, sort, 2, 10, parameters, null);
                 Assert.AreEqual("PagedSQL", result);
                 ClassMap.Verify();
                 sortField.Verify();
@@ -288,12 +288,12 @@ namespace DapperExtensions.Test.Sql
                 predicate.Setup(p => p.GetSql(Generator.Object, parameters)).Returns("PredicateWhere");
 
                 Generator.Setup(g => g.GetTableName(ClassMap.Object)).Returns("TableName").Verifiable();
-                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object)).Returns("Columns").Verifiable();
+                Generator.Setup(g => g.BuildSelectColumns(ClassMap.Object, null)).Returns("Columns").Verifiable();
                 Generator.Setup(g => g.GetColumnName(ClassMap.Object, "SortProperty", false)).Returns("SortColumn").Verifiable();
 
                 Dialect.Setup(d => d.GetSetSql("SELECT Columns FROM TableName WHERE PredicateWhere ORDER BY SortColumn ASC", 2, 10, parameters)).Returns("PagedSQL").Verifiable();
 
-                var result = Generator.Object.SelectSet(ClassMap.Object, predicate.Object, sort, 2, 10, parameters);
+                var result = Generator.Object.SelectSet(ClassMap.Object, predicate.Object, sort, 2, 10, parameters, null);
                 Assert.AreEqual("PagedSQL", result);
                 ClassMap.Verify();
                 sortField.Verify();
@@ -486,7 +486,7 @@ namespace DapperExtensions.Test.Sql
             [Test]
             public void WithNullPredicate_ThrowsException()
             {
-                var ex = Assert.Throws<ArgumentNullException>(() => Generator.Object.Update(ClassMap.Object, null, new Dictionary<string, object>(), false));
+                var ex = Assert.Throws<ArgumentNullException>(() => Generator.Object.Update(ClassMap.Object, null, new Dictionary<string, object>(), false, null));
                 StringAssert.Contains("cannot be null", ex.Message);
                 Assert.AreEqual("Predicate", ex.ParamName);
             }
@@ -495,7 +495,7 @@ namespace DapperExtensions.Test.Sql
             public void WithNullParameters_ThrowsException()
             {
                 Mock<IPredicate> predicate = new Mock<IPredicate>();
-                var ex = Assert.Throws<ArgumentNullException>(() => Generator.Object.Update(ClassMap.Object, predicate.Object, null, false));
+                var ex = Assert.Throws<ArgumentNullException>(() => Generator.Object.Update(ClassMap.Object, predicate.Object, null, false, null));
                 StringAssert.Contains("cannot be null", ex.Message);
                 Assert.AreEqual("Parameters", ex.ParamName);
             }
@@ -520,7 +520,7 @@ namespace DapperExtensions.Test.Sql
                 Mock<IPredicate> predicate = new Mock<IPredicate>();
                 Dictionary<string, object> parameters = new Dictionary<string, object>();
 
-                var ex = Assert.Throws<ArgumentException>(() => Generator.Object.Update(ClassMap.Object, predicate.Object, parameters, false));
+                var ex = Assert.Throws<ArgumentException>(() => Generator.Object.Update(ClassMap.Object, predicate.Object, parameters, false, null));
 
                 StringAssert.Contains("columns were mapped", ex.Message);
                 ClassMap.Verify();
@@ -555,7 +555,7 @@ namespace DapperExtensions.Test.Sql
                 Dictionary<string, object> parameters = new Dictionary<string, object>();
                 predicate.Setup(p => p.GetSql(Generator.Object, parameters)).Returns("Predicate").Verifiable();
                 
-                var result = Generator.Object.Update(ClassMap.Object, predicate.Object, parameters, false);
+                var result = Generator.Object.Update(ClassMap.Object, predicate.Object, parameters, false, null);
 
                 Assert.AreEqual("UPDATE TableName SET Column = @Name WHERE Predicate", result);
 
@@ -596,7 +596,7 @@ namespace DapperExtensions.Test.Sql
                 Dictionary<string, object> parameters = new Dictionary<string, object>();
                 predicate.Setup(p => p.GetSql(Generator.Object, parameters)).Returns("Predicate").Verifiable();
 
-                var result = Generator.Object.Update(ClassMap.Object, predicate.Object, parameters, false);
+                var result = Generator.Object.Update(ClassMap.Object, predicate.Object, parameters, false, null);
 
                 Assert.AreEqual("UPDATE TableName SET Column = @Name WHERE Predicate", result);
 
@@ -637,7 +637,7 @@ namespace DapperExtensions.Test.Sql
                 Dictionary<string, object> parameters = new Dictionary<string, object>();
                 predicate.Setup(p => p.GetSql(Generator.Object, parameters)).Returns("Predicate").Verifiable();
 
-                var result = Generator.Object.Update(ClassMap.Object, predicate.Object, parameters, false);
+                var result = Generator.Object.Update(ClassMap.Object, predicate.Object, parameters, false, null);
 
                 Assert.AreEqual("UPDATE TableName SET Column = @Name WHERE Predicate", result);
 
@@ -827,7 +827,7 @@ namespace DapperExtensions.Test.Sql
                 Generator.Setup(g => g.GetColumnName(ClassMap.Object, property2.Object, true)).Returns("Column2").Verifiable();
                 ClassMap.SetupGet(c => c.Properties).Returns(properties).Verifiable();
 
-                var result = Generator.Object.BuildSelectColumns(ClassMap.Object);
+                var result = Generator.Object.BuildSelectColumns(ClassMap.Object, null);
                 Assert.AreEqual("Column1, Column2", result);
                 ClassMap.Verify();
                 Generator.Verify();
@@ -848,7 +848,7 @@ namespace DapperExtensions.Test.Sql
                 Generator.Setup(g => g.GetColumnName(ClassMap.Object, property2.Object, true)).Returns("Column2").Verifiable();
                 ClassMap.SetupGet(c => c.Properties).Returns(properties).Verifiable();
 
-                var result = Generator.Object.BuildSelectColumns(ClassMap.Object);
+                var result = Generator.Object.BuildSelectColumns(ClassMap.Object, null);
                 Assert.AreEqual("Column2", result);
                 ClassMap.Verify();
                 Generator.Verify();

--- a/DapperExtensions.sln
+++ b/DapperExtensions.sln
@@ -1,6 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2046
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DapperExtensions", "DapperExtensions\DapperExtensions.csproj", "{4C1A2C6C-A469-4C87-98D1-F1D517FA1ACF}"
 EndProject
@@ -18,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{7F5566
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DapperExtensions.Net45", "DapperExtensions.Net45\DapperExtensions.Net45.csproj", "{1656EC3C-7876-4C67-9650-C61ACB806D35}"
+EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "DapperExtensionsDNXCore", "DapperExtensionsDNXCore\DapperExtensionsDNXCore.xproj", "{CAA1A673-6521-4954-BF05-37FFE016E5C3}"
 EndProject
 Global
@@ -95,5 +97,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {942ECB59-8E32-4B24-B05E-6C7144448D45}
 	EndGlobalSection
 EndGlobal

--- a/DapperExtensions/DapperExtensions.cs
+++ b/DapperExtensions/DapperExtensions.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Text;
 using DapperExtensions.Sql;
 using DapperExtensions.Mapper;
+using System.Linq.Expressions;
 
 namespace DapperExtensions
 {
@@ -141,6 +142,14 @@ namespace DapperExtensions
         }
 
         /// <summary>
+        /// Executes a query for the specified id, returning the data typed as per T
+        /// </summary>
+        public static TOut GetPartial<TIn, TOut>(this IDbConnection connection, dynamic id, Expression<Func<TIn, TOut>> func, IDbTransaction transaction = null, int? commandTimeout = null) where TIn : class where TOut : class
+        {
+            return Instance.GetPartial<TIn, TOut>(connection, func, id, transaction, commandTimeout);
+        }
+
+        /// <summary>
         /// Executes an insert query for the specified entity.
         /// </summary>
         public static void Insert<T>(this IDbConnection connection, IEnumerable<T> entities, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
@@ -165,6 +174,15 @@ namespace DapperExtensions
         public static bool Update<T>(this IDbConnection connection, T entity, IDbTransaction transaction = null, int? commandTimeout = null, bool ignoreAllKeyProperties = false) where T : class
         {
             return Instance.Update<T>(connection, entity, transaction, commandTimeout, ignoreAllKeyProperties);
+        }
+
+
+        /// <summary>
+        /// Executes some column an update query for the specified entity, as typed by LINq expresion
+        /// </summary>
+        public static bool UpdatePartial<TIn, TOut>(this IDbConnection connection, TIn entity, Expression<Func<TIn, TOut>> func, IDbTransaction transaction = null, int? commandTimeout = null, bool ignoreAllKeyProperties = false) where TIn : class where TOut : class
+        { 
+            return Instance.UpdatePartial<TIn, TOut>(connection, entity, func, transaction, commandTimeout, ignoreAllKeyProperties);
         }
 
         /// <summary>
@@ -192,12 +210,30 @@ namespace DapperExtensions
         }
 
         /// <summary>
+        /// Executes a select query using the specified predicate, returning an IEnumerable data typed as per LINq Expression.
+        /// </summary>
+        public static IEnumerable<TOut> GetPartialList<TIn, TOut>(this IDbConnection connection, Expression<Func<TIn, TOut>> func, object predicate = null, IList<ISort> sort = null, IDbTransaction transaction = null, int? commandTimeout = null, bool buffered = false) where TIn : class
+        {
+            return Instance.GetPartialList(connection, func, predicate, sort, transaction, commandTimeout, buffered);
+
+        }
+
+        /// <summary>
         /// Executes a select query using the specified predicate, returning an IEnumerable data typed as per T.
         /// Data returned is dependent upon the specified page and resultsPerPage.
         /// </summary>
         public static IEnumerable<T> GetPage<T>(this IDbConnection connection, object predicate, IList<ISort> sort, int page, int resultsPerPage, IDbTransaction transaction = null, int? commandTimeout = null, bool buffered = false) where T : class
         {
             return Instance.GetPage<T>(connection, predicate, sort, page, resultsPerPage, transaction, commandTimeout, buffered);
+        }
+
+        /// <summary>
+        /// Executes a select query using the specified predicate, returning an IEnumerable data typed as per LINq expression.
+        /// Data returned is dependent upon the specified page and resultsPerPage.
+        /// </summary>
+        public static IEnumerable<TOut> GetPartialPage<TIn, TOut>(this IDbConnection connection, Expression<Func<TIn, TOut>> func, object predicate, IList<ISort> sort, int page, int resultsPerPage, IDbTransaction transaction = null, int? commandTimeout = null, bool buffered = false) where TIn : class where TOut : class
+        {
+            return Instance.GetPartialPage(connection, func, predicate, sort, page, resultsPerPage, transaction, commandTimeout, buffered);
         }
 
         /// <summary>
@@ -208,6 +244,19 @@ namespace DapperExtensions
         {
             return Instance.GetSet<T>(connection, predicate, sort, firstResult, maxResults, transaction, commandTimeout, buffered);
         }
+
+
+
+        /// <summary>
+        /// Executes a select query using the specified predicate, returning an IEnumerable data typed as per LINq expression.
+        /// Data returned is dependent upon the specified firstResult and maxResults.
+        /// </summary>
+        public static IEnumerable<TOut> GetPartialSet<TIn, TOut>(this IDbConnection connection, Expression<Func<TIn, TOut>> func, object predicate, IList<ISort> sort, int firstResult, int maxResults, IDbTransaction transaction = null, int? commandTimeout = null, bool buffered = false) where TIn : class where TOut : class
+        {
+            return Instance.GetPartialSet<TIn, TOut>(connection, func, predicate, sort, firstResult, maxResults, transaction, commandTimeout, buffered);
+        }
+
+
 
         /// <summary>
         /// Executes a query using the specified predicate, returning an integer that represents the number of rows that match the query.


### PR DESCRIPTION
There is actually no possibility in DapperExtension to select only some column of an object.
This patch allow to do this (Properties selection like existing in EntityFramework)

This is done by adding an argument to Select / Update Sql generator which filter columns.

Sample Code : 


        private class DbObject
        {
            public int Id { get; set; }
            public string Field1 { get; set; }
            public string Field2 { get; set; }
            public int Field3 { get; set; }
            public int Field4 { get; set; }

            public double Field5 { get; set; }
            public double Field6 { get; set; }
        }

        private static void Main(string[] args)
        {
            SqlConnection cn = new SqlConnection("");

            // single object of anonymous type with Field1   Field2  Field6
            var temp = cn.GetPartial(1, (DbObject a) => new { a.Field1, a.Field2, a.Field6 });

            // IEnumerable of anonymous type with Field1   Field2  Field6
            var temp_ienumerable = cn.GetPartialList((DbObject a) => new { a.Field1, a.Field2, a.Field6 });

            // IEnumerable of anonymous type with Field1   Field2  Field6 (ASync variant)
            var temp_enumerableasync = cn.GetPartialListAsync((DbObject a) => new { a.Field1, a.Field2, a.Field6 });
       
        }
        
