### PR TITLE
Changed Map() method so it will accept a second call to Map() for any…

### DIFF
--- a/DapperExtensions.Test/Mapper/AutoClassMapperFixture.cs
+++ b/DapperExtensions.Test/Mapper/AutoClassMapperFixture.cs
@@ -1,6 +1,7 @@
 ﻿using DapperExtensions.Mapper;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -10,6 +11,44 @@ namespace DapperExtensions.Test.Mapper
     [Parallelizable(ParallelScope.All)]
     public static class AutoClassMapperFixture
     {
+        [TestFixture]
+        public class IListTests
+        {
+            [ExcludeFromCodeCoverage]
+            public class Foo
+            {
+                public IList<Bar> Bars { get; set; }
+            }
+
+            [ExcludeFromCodeCoverage]
+            public class Bar
+            {
+                public string Name { get; set; }
+            }
+
+            public class FooClassMapper : AutoClassMapper<Foo>
+            {
+                public FooClassMapper()
+                    : base()
+                {
+                    Map(f => f.Bars).Ignore();
+                }
+            }
+
+            private static bool MappingIsIgnored(FooClassMapper mapper)
+            {
+                return mapper.Properties.Any(w => w.Name == "Bars" && w.Ignored);
+            }
+
+            [Test]
+            public void IListIsIgnored()
+            {
+                var target = new FooClassMapper();
+
+                Assert.IsTrue(MappingIsIgnored(target));
+            }
+        }
+
         [TestFixture]
         public class AutoClassMapperTableName
         {

--- a/DapperExtensions/Mapper/ClassMapper.cs
+++ b/DapperExtensions/Mapper/ClassMapper.cs
@@ -175,14 +175,7 @@ namespace DapperExtensions.Mapper
             var result = new MemberMap(propertyInfo, this, parent: parent);
             if (GuardForDuplicatePropertyMap(result))
             {
-                if (propertyInfo.PropertyType.IsClass)
-                {
-                    result = (MemberMap)Properties.FirstOrDefault(p => p.Name.Equals(result.Name) && p.ParentProperty == result.ParentProperty);
-                }
-                else
-                {
-                    throw new ApplicationException("Unable to UnMap because mapping does not exist.");
-                }
+                result = (MemberMap)Properties.FirstOrDefault(p => p.Name.Equals(result.Name) && p.ParentProperty == result.ParentProperty);
             }
             else
             {


### PR DESCRIPTION
… property type, not just for properties where IsClass == true. This allows us to Map().Ignore() properties that the AutoClassMapper has mapped automatically, such as lists.

See #266 for details.