### PR TITLE
adding bit flag check ability

### DIFF
--- a/DapperExtensions.Test/PredicatesFixture.cs
+++ b/DapperExtensions.Test/PredicatesFixture.cs
@@ -148,6 +148,16 @@ namespace DapperExtensions.Test
                 Assert.AreEqual(values, predicate.Collection);
                 Assert.AreEqual(false, predicate.Not);
             }
+
+            [Test]
+            public void BitEq_ReturnsSetupPredicate()
+            {
+                var predicate = Predicates.Field<PredicateTestEntity>(f => f.Id, Operator.BitEq, 1, false);
+                Assert.AreEqual("Id", predicate.PropertyName);
+                Assert.AreEqual(Operator.BitEq, predicate.Operator);
+                Assert.AreEqual(1, predicate.Value);
+                Assert.AreEqual(false, predicate.Not);
+            }
         }
 
         [TestFixture]

--- a/DapperExtensions/Predicate/FieldPredicate.cs
+++ b/DapperExtensions/Predicate/FieldPredicate.cs
@@ -97,6 +97,10 @@ namespace DapperExtensions.Predicate
 
             var format = (Operator == Operator.Like && Value != null && sqlGenerator.Configuration.Dialect is OracleDialect) ?
                     "(upper({0}) {1} upper('%'||{2}||'%'))" : "({0} {1} {2})";
+            if (Operator == Operator.BitEq && Value != null)
+            {
+                format = (sqlGenerator.Configuration.Dialect is OracleDialect) ? "BITAND({0}, {2}) {1} {2}" : "{0}&{2} {1} {2}";
+            }
 
             return string.Format(format, columnName, GetOperatorString(), GetParameterName(sqlGenerator, parameters, parameterPropertyName, parentType));
         }

--- a/DapperExtensions/Predicate/PredicateEnums.cs
+++ b/DapperExtensions/Predicate/PredicateEnums.cs
@@ -18,6 +18,11 @@
         Eq,
 
         /// <summary>
+        /// Bit Equal (flags)
+        /// </summary>
+        BitEq,
+
+        /// <summary>
         /// Greater than
         /// </summary>
         Gt,


### PR DESCRIPTION
running queries to determine if 33 has the 32 bit set (100000 & 100001) isn't possible currently with dapper extensions.  This addition should allow that for all the defined dialects

For Oracle:
```Sql
BITAND(FlagField, 32) = 32
```
everyone else
```Sql
FlagField&32 = 32
```