### PR TITLE
Get by id creates empty predicate.

### DIFF
--- a/DapperExtensions.Test/IntegrationTests/SqlServer/CrudFixture.cs
+++ b/DapperExtensions.Test/IntegrationTests/SqlServer/CrudFixture.cs
@@ -64,6 +64,15 @@ namespace DapperExtensions.Test.IntegrationTests.SqlServer
             [Test]
             public void UsingKey_ReturnsEntity()
             {
+                Person p0 = new Person
+                {
+                    Active = true,
+                    FirstName = "Foo",
+                    LastName = "Bar",
+                    DateCreated = DateTime.UtcNow
+                };
+                Db.Insert(p0);
+
                 Person p1 = new Person
                 {
                     Active = true,


### PR DESCRIPTION
The test case on master currently works because there is only 1 row in the database, so select without a where returns 1 row as expected.

Added breaking test case for SQL Server Get, though this bug may affect all providers.

The predicate is not filled out when using Get(value) but they work when using Get(object). I noticed that in `DapperImplementor.GetMapAndPredicate`, GetKeyPredicate is only called for Update and Delete, not Get.

This pull request does not fix anything, it will start to fail the build because this is a bug.

Workaround for developers trying to use Get is to use Get(new {}) syntax.

Workaround for Dapper-Extensions is to fix the documentation to say Get(new { id }) instead of Get(id).